### PR TITLE
fix: fall back to default DSH home and persist into the active session workspace

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -68,12 +68,14 @@ window.__ModuleLoader__.load({
     }
 
     /** Upload one file to the host and resolve its workspace path. */
-    function upload(file) {
+    function upload(file, workspace) {
       return file.arrayBuffer().then(function (buffer) {
+        var payload = { name: file.name, dataBase64: toBase64(buffer) }
+        if (workspace && typeof workspace === 'string' && workspace.length > 0) payload.workspace = workspace
         return fetch(IMPORT_ROUTE, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: file.name, dataBase64: toBase64(buffer) }),
+          body: JSON.stringify(payload),
         })
       }).then(function (response) {
         return response.json().then(function (result) {
@@ -83,6 +85,19 @@ window.__ModuleLoader__.load({
           return result.value.path
         })
       })
+    }
+
+    /** Workspace path of the given (or current) session, from the sessions service. */
+    function currentWorkspace(sessions, sessionId) {
+      try {
+        var state = sessions && sessions.list ? sessions.list.getSnapshot() : undefined
+        if (!state) return undefined
+        var id = sessionId || state.current
+        if (!id) return undefined
+        var row = state.byId ? state.byId[id] : undefined
+        return row && typeof row.cwd === 'string' && row.cwd.length > 0 ? row.cwd : undefined
+      } catch (error) { /* best-effort */ }
+      return undefined
     }
 
     /** Short red notice near the top of the page; removed automatically. */
@@ -229,10 +244,11 @@ window.__ModuleLoader__.load({
     }
 
     /** Upload a batch of files in order, adding a chip per file (no composer text). */
-    function enqueueFiles(files) {
+    function enqueueFiles(files, sessions) {
+      var ws = currentWorkspace(sessions)
       var chain = Promise.resolve()
       files.forEach(function (file) {
-        chain = chain.then(function () { return upload(file) }).then(function (path) {
+        chain = chain.then(function () { return upload(file, ws) }).then(function (path) {
           addFile(path, file.name)
         }).catch(function (error) {
           console.error('[drop-to-path] file upload failed:', error)
@@ -242,7 +258,7 @@ window.__ModuleLoader__.load({
     }
 
     /** Intercept drops/pastes that contain non-image supported files. */
-    function installFileInterception() {
+    function installFileInterception(sessions) {
       var onDrop = function (event) {
         var files = Array.prototype.slice.call(event.dataTransfer ? event.dataTransfer.files : [])
         var supported = files.filter(isSupportedFile)
@@ -257,7 +273,7 @@ window.__ModuleLoader__.load({
         // Mixed or file-only drop: intercept.
         event.preventDefault()
         event.stopPropagation()
-        enqueueFiles(others)
+        enqueueFiles(others, sessions)
 
         var target = event.target
         // Mixed drop: re-dispatch the images as a pure-image drop. The
@@ -272,12 +288,12 @@ window.__ModuleLoader__.load({
                 target.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }))
               } catch (error) {
                 console.error('[drop-to-path] image re-dispatch failed, uploading as paths:', error)
-                enqueueFiles(images)
+                enqueueFiles(images, sessions)
               }
             }, 0)
           } catch (error) {
             console.error('[drop-to-path] image re-dispatch setup failed, uploading as paths:', error)
-            enqueueFiles(images)
+            enqueueFiles(images, sessions)
           }
         }
 
@@ -299,7 +315,7 @@ window.__ModuleLoader__.load({
         if (supported.every(isImageFile)) return
         event.preventDefault()
         event.stopPropagation()
-        enqueueFiles(supported)
+        enqueueFiles(supported, sessions)
       }
 
       document.addEventListener('drop', onDrop, true)
@@ -311,7 +327,7 @@ window.__ModuleLoader__.load({
     }
 
     /** Wrap conversation.sendSession on the prototype: images + chips → paths. */
-    function patchSendSession(conversation) {
+    function patchSendSession(conversation, sessions) {
       var proto = conversation.constructor && conversation.constructor.prototype
       if (!proto || typeof proto.sendSession !== 'function' || proto[PATCH_MARK]) return
       proto[PATCH_MARK] = true
@@ -330,13 +346,14 @@ window.__ModuleLoader__.load({
           if (attachments.length !== imageIds.length) return original.call(this, session, text, imageIds, mode)
         }
 
+        var ws = currentWorkspace(sessions, session && session.sessionId)
         var paths = filePaths.slice()
         try {
           if (hasImages) {
             for (var i = 0; i < attachments.length; i++) {
               var file = attachments[i] && attachments[i].file
               if (!file) continue
-              paths.push(await upload(file))
+              paths.push(await upload(file, ws))
             }
           }
         } catch (error) {
@@ -374,15 +391,16 @@ window.__ModuleLoader__.load({
       } catch (error) { /* best-effort */ }
 
       var conversation = ctx.conversation
+      var sessions = ctx.sessions
       if (conversation && typeof conversation.sendSession === 'function') {
-        patchSendSession(conversation)
+        patchSendSession(conversation, sessions)
       }
       var ta = findComposer()
       if (ta) ensureChipsObserver(ta)
-      ctx.effect(installFileInterception, 'drop-to-path: non-image file interception')
+      ctx.effect(function () { return installFileInterception(sessions) }, 'drop-to-path: non-image file interception')
     }
 
-    exports.inject = ['conversation']
+    exports.inject = ['conversation', 'sessions']
     exports.apply = apply
     return module.exports
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { basename, join } from 'node:path'
+import { basename, isAbsolute, join } from 'node:path'
+import { homedir } from 'node:os'
 
 export const IMPORT_ROUTE = '/_dsh/drop-to-path/import'
 
@@ -45,8 +46,7 @@ async function readBody(req, limit) {
 
 /** Resolve the active session workspace root from the durable workspace registry. */
 async function workspaceRoot() {
-  const dshHome = process.env.DSH_HOME
-  if (!dshHome || dshHome.length === 0) throw new Error('DSH_HOME is not set')
+  const dshHome = process.env.DSH_HOME || join(homedir(), '.dsh')
   const store = join(dshHome, 'storages', 'workspace.json')
   let parsed
   try {
@@ -101,11 +101,17 @@ export async function apply(ctx) {
               respond({ ok: false, error: { code: 'invalid-request', message: error instanceof Error ? error.message : String(error) } }, 400)
               return
             }
-            const { name: rawName, dataBase64 } = body
+            const { name: rawName, dataBase64, workspace: clientWorkspace } = body
             if (typeof dataBase64 !== 'string' || dataBase64.length === 0) {
               respond({ ok: false, error: { code: 'invalid-request', message: 'Missing dataBase64' } }, 400)
               return
             }
+            // Trust the client-supplied active workspace only when it is an
+            // absolute path; otherwise fall back to the registry scan so a
+            // stale or tampered payload can never write outside a real root.
+            const root = typeof clientWorkspace === 'string' && isAbsolute(clientWorkspace)
+              ? clientWorkspace
+              : await workspaceRoot()
             const bytes = Buffer.from(dataBase64, 'base64')
             const safe = safeName(rawName)
             const dot = safe.lastIndexOf('.')
@@ -122,7 +128,6 @@ export async function apply(ctx) {
               respond({ ok: false, error: { code: 'too-large', message: `File exceeds ${Math.floor(limit / 1024 / 1024)}MB` } }, 413)
               return
             }
-            const root = await workspaceRoot()
             const dir = join(root, DROP_DIR)
             await mkdir(dir, { recursive: true })
             const target = join(dir, `${Date.now()}-${safe}`)


### PR DESCRIPTION
## Summary

Fixes #1 and the related multi-workspace issue called out there.

### Problem 1 — `DSH_HOME is not set`

`workspaceRoot()` hard-required `process.env.DSH_HOME` and threw when DSH runs without that env var. DSH itself never requires it: `@deepseek-ai/dsh-home-paths` resolves `~/.dsh` as the default, so a normal `dsh web` launch (no exported `DSH_HOME`) is a valid, common setup.

**Fix (host):** fall back to `join(homedir(), '.dsh')` when `DSH_HOME` is unset.

### Problem 2 — files land in the wrong workspace

`workspaceRoot()` picked the workspace with the newest `updatedAt` in `workspace.json`, which is not necessarily the workspace the user is actively chatting in. In multi-workspace setups the uploaded file (and therefore the path the model sees) pointed at a different project directory.

**Fix (host + client):**
- The browser resolves the **active session's workspace** via the `sessions` service (`sessions.list.getSnapshot()` → `byId[sessionId].cwd`, falling back to `state.current`) and sends it with each upload as `workspace`.
- The host trusts the client-supplied workspace **only when it is an absolute path** (`isAbsolute`), falling back to the registry scan otherwise, so a stale or tampered payload can never write outside a real root.
- Applies to both paths: image uploads in the patched `sendSession` and non-image file chips (`enqueueFiles`) — including the drop re-dispatch fallbacks.

## Verification

Tested locally against `@deepseek-ai/dsh@0.1.0-rc.6` (web profile): with these changes the import route works without `DSH_HOME` set, and files persist into the workspace of the session that actually sent them. `node --check` passes on both files.

## Notes

- `exports.inject` on the client now declares `sessions` in addition to `conversation`.
- No API changes; the `workspace` request field is optional and backward compatible.